### PR TITLE
Remove GetProperties calls

### DIFF
--- a/snippets/glad
+++ b/snippets/glad
@@ -8,7 +8,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(glad)
 FetchContent_MakeAvailable(glad)
 
 target_link_libraries(_TARGET_ glad)

--- a/snippets/glfw
+++ b/snippets/glfw
@@ -9,7 +9,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(glfw)
 FetchContent_MakeAvailable(glfw)
 
 target_link_libraries(_TARGET_ glfw)

--- a/snippets/glm
+++ b/snippets/glm
@@ -5,7 +5,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
 	GIT_SHALLOW         TRUE	
 )
-FetchContent_GetProperties(glm)
 FetchContent_MakeAvailable(glm)
 
 target_link_libraries(_TARGET_ glm)

--- a/snippets/nlohmann_json
+++ b/snippets/nlohmann_json
@@ -4,7 +4,6 @@ FetchContent_Declare(json
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(json)
 FetchContent_MakeAvailable(json)
 
 target_link_libraries(_TARGET_ nlohmann_json::nlohmann_json)

--- a/snippets/sockcpp
+++ b/snippets/sockcpp
@@ -7,7 +7,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(sockpp)
 FetchContent_MakeAvailable(sockpp)
 
 target_link_libraries(_TARGET_ sockpp-static)

--- a/snippets/spdlog
+++ b/snippets/spdlog
@@ -5,7 +5,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(spdlog)
 FetchContent_MakeAvailable(spdlog)
 
 target_link_libraries(_TARGET_ spdlog::spdlog)

--- a/snippets/turbogui
+++ b/snippets/turbogui
@@ -4,7 +4,6 @@ FetchContent_Declare(
     GIT_REPOSITORY      https://github.com/Heerdam/TurboGUI
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(turbogui)
 FetchContent_MakeAvailable(turbogui)
 
 target_link_libraries(_TARGET_ turbogui)

--- a/snippets/wxwidgets
+++ b/snippets/wxwidgets
@@ -8,7 +8,6 @@ FetchContent_Declare(
     GIT_TAG             _TAG_
     GIT_SHALLOW         TRUE
 )
-FetchContent_GetProperties(wxWidgets)
 FetchContent_MakeAvailable(wxWidgets)
 
 target_link_libraries(_TARGET_ wxnet wxcore wxbase)


### PR DESCRIPTION
`FetchContent_GetProperties` is not neccessary when `FetchContent_MakeAvailable` is used.